### PR TITLE
Added ability for SDK to set the roles of a user.

### DIFF
--- a/lib/looker-sdk/client/users.rb
+++ b/lib/looker-sdk/client/users.rb
@@ -150,28 +150,16 @@ module LookerSDK
         paginate "users/#{user}/roles", options
       end
 
-      # Add role to user
+      # set the roles that a user belongs to.
       #
       # @param user [Integer] User id.
-      # @param role_id [Integer] Id of new role.
-      # @return [Boolean] True on successful addition, false otherwise.
+      # @param role_ids [Array<Integer>] Ids of new roles.
+      # @return [Sawyer::Resource] updated set of roles that the user is now in.
       # @see look TODO docs link
       # @example
-      #   LookerSDK.add_role(1, 1)
-      def add_user_role(user, role_id, options = {})
-        boolean_from_response :put, "users/#{user}/roles/#{role_id}", options
-      end
-
-      # Remove role from user.
-      #
-      # @param user [Integer] User id.
-      # @param role_id [Integer] Id of role to remove
-      # @return [Boolean] True if user removed, false otherwise.
-      # @see look TODO docs link
-      # @example
-      #   LookerSDK.remove_role(1, 1)
-      def remove_user_role(user, role_id, options = {})
-        boolean_from_response :delete, "users/#{user}/roles/#{role_id}", options
+      #   LookerSDK.set_user_roles(1, [role1.id, role2.id])
+      def set_user_roles(user, roles, options = {})
+        put "users/#{user}/roles", options.merge(:roles => roles)
       end
     end
 

--- a/test/cassettes/LookerSDK_Client_Users_set_user_roles/sets_the_users_roles.yml
+++ b/test/cassettes/LookerSDK_Client_Users_set_user_roles/sets_the_users_roles.yml
@@ -1,0 +1,448 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/users
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '293'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":195,"first_name":null,"last_name":null,"email":null,"models_dir":null,"is_disabled":false,"look_access":[195],"avatar_url":"https://www.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=156&d=mm","credentials_email":null,"models":[],"url":"http://localhost:19999/api/3.0/users/195"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/role_types
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role_type","permissions":["administer"]}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '134'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/role_domains
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role_domain","models":"all"}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '160'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role1","role_domain_id":13,"role_type_id":11}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":28,"name":"test_role1","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/28","users_url":"http://localhost:19999/api/3.0/roles/28/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role2","role_domain_id":13,"role_type_id":11}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":29,"name":"test_role2","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/29","users_url":"http://localhost:19999/api/3.0/roles/29/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role3","role_domain_id":13,"role_type_id":11}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":30,"name":"test_role3","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/30","users_url":"http://localhost:19999/api/3.0/roles/30/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role4","role_domain_id":13,"role_type_id":11}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":31,"name":"test_role4","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/31","users_url":"http://localhost:19999/api/3.0/roles/31/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role5","role_domain_id":13,"role_type_id":11}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":32,"name":"test_role5","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/32","users_url":"http://localhost:19999/api/3.0/roles/32/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: put
+    uri: http://localhost:19999/api/3.0/users/195/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"roles":[28,29,30,31,32]}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '2301'
+    body:
+      encoding: US-ASCII
+      string: ! '[{"id":28,"name":"test_role1","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/28","users_url":"http://localhost:19999/api/3.0/roles/28/users"},{"id":29,"name":"test_role2","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/29","users_url":"http://localhost:19999/api/3.0/roles/29/users"},{"id":30,"name":"test_role3","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/30","users_url":"http://localhost:19999/api/3.0/roles/30/users"},{"id":31,"name":"test_role4","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/31","users_url":"http://localhost:19999/api/3.0/roles/31/users"},{"id":32,"name":"test_role5","role_type":{"id":11,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/11"},"role_domain":{"id":13,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/13"},"url":"http://localhost:19999/api/3.0/roles/32","users_url":"http://localhost:19999/api/3.0/roles/32/users"}]'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/28
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/29
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/30
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/31
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/32
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/role_types/11
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/role_domains/13
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:44 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/users/195
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:04:45 GMT
+recorded_with: VCR 2.9.2

--- a/test/cassettes/LookerSDK_Client_Users_set_user_roles/wont_set_duplicate_roles.yml
+++ b/test/cassettes/LookerSDK_Client_Users_set_user_roles/wont_set_duplicate_roles.yml
@@ -1,0 +1,448 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/users
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '293'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":196,"first_name":null,"last_name":null,"email":null,"models_dir":null,"is_disabled":false,"look_access":[196],"avatar_url":"https://www.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=156&d=mm","credentials_email":null,"models":[],"url":"http://localhost:19999/api/3.0/users/196"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:11 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/role_types
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role_type","permissions":["administer"]}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '134'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:11 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/role_domains
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role_domain","models":"all"}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '160'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:11 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role1","role_domain_id":14,"role_type_id":12}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":33,"name":"test_role1","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/33","users_url":"http://localhost:19999/api/3.0/roles/33/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:11 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role2","role_domain_id":14,"role_type_id":12}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":34,"name":"test_role2","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/34","users_url":"http://localhost:19999/api/3.0/roles/34/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:11 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role3","role_domain_id":14,"role_type_id":12}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":35,"name":"test_role3","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/35","users_url":"http://localhost:19999/api/3.0/roles/35/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:11 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role4","role_domain_id":14,"role_type_id":12}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":36,"name":"test_role4","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/36","users_url":"http://localhost:19999/api/3.0/roles/36/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:11 GMT
+- request:
+    method: post
+    uri: http://localhost:19999/api/3.0/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"name":"test_role5","role_domain_id":14,"role_type_id":12}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '459'
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":37,"name":"test_role5","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/37","users_url":"http://localhost:19999/api/3.0/roles/37/users"}'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:11 GMT
+- request:
+    method: put
+    uri: http://localhost:19999/api/3.0/users/196/roles
+    body:
+      encoding: UTF-8
+      string: ! '{"roles":[33,34,35,36,37,33]}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '2301'
+    body:
+      encoding: US-ASCII
+      string: ! '[{"id":33,"name":"test_role1","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/33","users_url":"http://localhost:19999/api/3.0/roles/33/users"},{"id":34,"name":"test_role2","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/34","users_url":"http://localhost:19999/api/3.0/roles/34/users"},{"id":35,"name":"test_role3","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/35","users_url":"http://localhost:19999/api/3.0/roles/35/users"},{"id":36,"name":"test_role4","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/36","users_url":"http://localhost:19999/api/3.0/roles/36/users"},{"id":37,"name":"test_role5","role_type":{"id":12,"name":"test_role_type","permissions":["administer"],"all_access":false,"url":"http://localhost:19999/api/3.0/role_types/12"},"role_domain":{"id":14,"name":"test_role_domain","models":["thelook","thelook_netezza","thelook_sf"],"all_access":true,"url":"http://localhost:19999/api/3.0/role_domains/14"},"url":"http://localhost:19999/api/3.0/roles/37","users_url":"http://localhost:19999/api/3.0/roles/37/users"}]'
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/33
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/34
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/35
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/36
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/roles/37
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/role_types/12
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/role_domains/14
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+- request:
+    method: delete
+    uri: http://localhost:19999/api/3.0/users/196
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      Accept:
+      - application/vnd.looker.v3+json
+      User-Agent:
+      - Looker Ruby Gem 0.0.2
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 18:07:12 GMT
+recorded_with: VCR 2.9.2

--- a/test/looker/client/test_users.rb
+++ b/test/looker/client/test_users.rb
@@ -127,5 +127,44 @@ describe LookerSDK::Client::Users do
       roles = LookerSDK.user_roles(user[:id])
     end
   end
+
+  describe ".set_user_roles", :vcr do
+    it "sets the users roles" do
+      user = LookerSDK.create_user
+      role_type = LookerSDK.create_role_type(:name => "test_role_type", :permissions => ["administer"])
+      role_domain = LookerSDK.create_role_domain(:name => "test_role_domain", :models => "all")
+      roles = (1..5).map {|i| LookerSDK.create_role(:name => "test_role#{i}", :role_domain_id => role_domain.id, :role_type_id => role_type.id) }
+
+      new_role_ids = LookerSDK.set_user_roles(user.id, roles.map {|role| role.id}).map {|role| role.id}
+
+      roles.each do |role|
+        new_role_ids.must_include role.id
+      end
+
+      roles.each do |role|
+        LookerSDK.delete_role(role.id).must_equal true
+      end
+      LookerSDK.delete_role_type(role_type.id).must_equal true
+      LookerSDK.delete_role_domain(role_domain.id).must_equal true
+      LookerSDK.delete_user(user.id)
+    end
+
+    it "wont set duplicate roles" do
+      user = LookerSDK.create_user
+      role_type = LookerSDK.create_role_type(:name => "test_role_type", :permissions => ["administer"])
+      role_domain = LookerSDK.create_role_domain(:name => "test_role_domain", :models => "all")
+      roles = (1..5).map {|i| LookerSDK.create_role(:name => "test_role#{i}", :role_domain_id => role_domain.id, :role_type_id => role_type.id) }
+
+      new_role_ids = LookerSDK.set_user_roles(user.id, roles.map {|role| role.id} << roles.first.id).map {|role| role.id}
+      new_role_ids.select {|role_id| role_id == roles.first.id}.length.must_equal 1
+
+      roles.each do |role|
+        LookerSDK.delete_role(role.id).must_equal true
+      end
+      LookerSDK.delete_role_type(role_type.id).must_equal true
+      LookerSDK.delete_role_domain(role_domain.id).must_equal true
+      LookerSDK.delete_user(user.id)
+    end
+  end
 end
 


### PR DESCRIPTION
removed code for add/remove user_role because the functionality did not exist. instead implemented the ability to set the roles of a user. @dmarcotte and I talked about this from the other side (setting the users of a role) as we will always be doing this. The only use case (that I can think of) of adding/removing roles from a user will be when a new role is created and you want to add this role to a user (without examining the other roles that the user is part of). However, this can be accomplished by simply setting the users of the role instead. 
