### PR TITLE
support custom faraday

### DIFF
--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -251,7 +251,7 @@ module LookerSDK
       conn_opts = @connection_options
       conn_opts[:builder] = @middleware if @middleware
       conn_opts[:proxy] = @proxy if @proxy
-      opts[:faraday] = Faraday.new(conn_opts)
+      opts[:faraday] = @faraday || Faraday.new(conn_opts)
 
       opts
     end

--- a/lib/looker-sdk/client/dynamic.rb
+++ b/lib/looker-sdk/client/dynamic.rb
@@ -3,8 +3,14 @@ module LookerSDK
 
     module Dynamic
 
+      def try_load_swagger
+        body = get('swagger.json') rescue nil
+        last_response && last_response.status == 200 && body
+      end
+
       def load_swagger
-        @swagger ||= without_authentication {get('swagger.json') rescue nil} || (get('swagger.json') rescue nil)
+        # Try to load w/o authenticating. Else, authenticate and try again.
+        @swagger ||= without_authentication {try_load_swagger} || try_load_swagger
       end
 
       def operations

--- a/lib/looker-sdk/configurable.rb
+++ b/lib/looker-sdk/configurable.rb
@@ -42,7 +42,7 @@ module LookerSDK
     attr_accessor :access_token, :auto_paginate, :client_id,
                   :client_secret, :default_media_type, :connection_options,
                   :middleware, :netrc, :netrc_file,
-                  :per_page, :proxy, :user_agent
+                  :per_page, :proxy, :user_agent, :faraday
     attr_writer :web_endpoint, :api_endpoint
 
     class << self
@@ -64,6 +64,7 @@ module LookerSDK
           :per_page,
           :proxy,
           :user_agent,
+          :faraday,
           :web_endpoint
         ]
       end

--- a/lib/looker-sdk/default.rb
+++ b/lib/looker-sdk/default.rb
@@ -89,6 +89,10 @@ module LookerSDK
         MIDDLEWARE
       end
 
+      def faraday
+        nil
+      end
+
       # Default pagination page size from ENV
       # @return [Fixnum] Page size
       def per_page


### PR DESCRIPTION
Pass thru and use a faraday object specified be the embedding.
This enables us to use the ':rake' faraday adpater in helltool tests
so that we can make calls to core via the sdk in tests that flow
through rake-test and not real http.

Also, ensure that swagger loading doesn't do the wrong thing when
there is a 404 with a body.
