### PR TITLE
fix alive. add alternative. fix #55

### DIFF
--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -190,8 +190,32 @@ module LookerSDK
     #
     # @return http status code
     def alive
-      get '/alive'
+      without_authentication do
+        get '/alive'
+      end
       last_response.status
+    end
+
+    # Are we connected to the server? - Does not attempt to authenticate.
+    def alive?
+      begin
+        without_authentication do
+          get('/alive')
+        end
+        true
+      rescue
+        false
+      end
+    end
+
+    # Are we connected and authenticated to the server?
+    def authenticated?
+      begin
+        ensure_logged_in
+        true
+      rescue
+        false
+      end
     end
 
     # Response for last HTTP request

--- a/shell/shell.rb
+++ b/shell/shell.rb
@@ -26,7 +26,8 @@ end
 
 begin
   puts "Connecting to Looker at '#{sdk.api_endpoint}'"
-  puts (code = sdk.alive) == 200 ? "Looker is alive!" : "Sad Looker: #{code}"
+  puts sdk.alive? ? "Looker is alive!" : "Sad Looker, can't connect:\n  #{sdk.last_error}"
+  puts sdk.authenticated? ? "Authenticated!" : "Sad Looker, can't authenticate:\n  #{sdk.last_error}"
 
   binding.pry self
 rescue Exception => e


### PR DESCRIPTION
As noted in #55, `alive` isn't skipping the authentication request as documented. This fixes that.
It is still a bit iffy in that in the failure cases it doesn't really return a useful http code - it does the 'normal' raising of an sdk exception instead. I don't think we should mess with that. Existing callers will want the success case to continue to work as it has been working IMO.

So, I'm proposing two new (additional) `?` methods that just return bool. Callers can leverage `last_error` to look at any captured exceptions if they choose. The shell is updated to use that.

I think I like this. I'm interested in feedback.