### PR TITLE
remove magic field name based integer timestamp to time conversion

### DIFF
--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -365,7 +365,7 @@ module LookerSDK
 
       # slight modification to the base class' decode_hash_value function to
       # less permissive when decoding time values.
-      # also prevent conversion from integer/float timestamp to Time
+      # also prevent conversion from non-string types to Time e.g. integer/float timestamp
       #
       # See https://github.com/looker/looker-sdk-ruby/issues/53 for more details
       #

--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -365,15 +365,20 @@ module LookerSDK
 
       # slight modification to the base class' decode_hash_value function to
       # less permissive when decoding time values.
+      # also prevent conversion from integer/float timestamp to Time
       #
       # See https://github.com/looker/looker-sdk-ruby/issues/53 for more details
       #
       # Base class function that we're overriding: https://github.com/lostisland/sawyer/blob/master/lib/sawyer/serializer.rb#L101-L121
       def decode_hash_value(key, value)
-        if time_field?(key, value) && value.is_a?(String)
-          begin
-            Time.iso8601(value)
-          rescue ArgumentError
+        if time_field?(key, value)
+          if value.is_a?(String)
+            begin
+              Time.iso8601(value)
+            rescue ArgumentError
+              value
+            end
+          else
             value
           end
         else

--- a/test/looker/test_client.rb
+++ b/test/looker/test_client.rb
@@ -212,12 +212,15 @@ describe LookerSDK::Client do
 
   describe 'Sawyer date/time parsing patch' do
     describe 'key matches time_field pattern' do
-      it 'does not modify non-iso date/time string' do
+      it 'does not modify non-iso date/time string or integer fields' do
         values = {
             :test_at => '30 days',
             :test_on => 'July 20, 1969',
             :test_date => '1968-04-03 12:23:34',  # this is not iso8601 format!
             :date => '2 months ago',
+            :test_int_at => 42,
+            :test_int_on => 42,
+            :test_int_date => 42,
         }
 
         serializer = LookerSDK::Client.new.send(:serializer)

--- a/test/looker/test_client.rb
+++ b/test/looker/test_client.rb
@@ -220,7 +220,10 @@ describe LookerSDK::Client do
             :date => '2 months ago',
             :test_int_at => 42,
             :test_int_on => 42,
-            :test_int_date => 42,
+            :test_int_date => 42.1,
+            :test_float_at => 42.1,
+            :test_float_on => 42.1,
+            :test_float_date => 42.1,
         }
 
         serializer = LookerSDK::Client.new.send(:serializer)


### PR DESCRIPTION
Ultimately the name based implicit type conversion should to go away completely, or maybe get rid of our dependence on Sawyer altogether a la #57

For now I am getting unstuck by removing the implicit type conversion for non-strings.

@jbandhauer or @jonathanswenson might have something to say.