### PR TITLE
require a compatible version of faraday

### DIFF
--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.add_dependency 'jruby-openssl' if s.platform == :jruby
   s.add_dependency 'sawyer', '~> 0.8'
+  s.add_dependency 'faraday', ['~> 0.9.2', '< 1.0']
 end


### PR DESCRIPTION
This line:

https://github.com/looker/looker-sdk-ruby/blob/7deaede99d6a939bf03d94cff41185b4fafddd7d/lib/looker-sdk/client.rb#L331-L332

requires Faraday 0.9.2 for the third parameter to be supported, but this gem doesn't enforce that dependency properly

You can see where Faraday adds this feature here: https://github.com/lostisland/faraday/commit/ad226f75ab979bde8f0dad3a99e2eed86a15272c