### PR TITLE
Allow higher versions of Faraday

### DIFF
--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.add_dependency 'jruby-openssl' if s.platform == :jruby
   s.add_dependency 'sawyer', '~> 0.8'
-  s.add_dependency 'faraday', ['~> 0.9.2', '< 1.0']
+  s.add_dependency 'faraday', ['>= 0.9.2', '< 1.0']
 end


### PR DESCRIPTION
We were not able to use this SDK because it did not higher versions of faraday.

Maybe I misunderstand how the `~>0.9.2` works but this fixed my issue.

