### PR TITLE
Added parens around method parameter as requested

### DIFF
--- a/lib/looker-sdk/authentication.rb
+++ b/lib/looker-sdk/authentication.rb
@@ -51,7 +51,7 @@ module LookerSDK
 
       set_access_token_from_params(nil)
       without_authentication do
-        encoded_auth = Faraday::Utils.build_query application_credentials
+        encoded_auth = Faraday::Utils.build_query(application_credentials)
         post("#{URI.parse(api_endpoint).path}/login", encoded_auth, header: {:'Content-Type' => 'application/x-www-form-urlencoded'})
         raise "login failure #{last_response.status}" unless last_response.status == 200
         set_access_token_from_params(last_response.data)


### PR DESCRIPTION
@jbandhauer 

Of course no need to release this, but you might as well accept the PR so that it will be cleaner in the future.