### PR TITLE
Encode path params before forming URI [EMBED-752]

### DIFF
--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -301,7 +301,7 @@ module LookerSDK
       begin
         @last_response = @last_error = nil
         return stream_request(method, path, data, options, &block) if block_given?
-        @last_response = response = agent.call(method, URI::Parser.new.escape(path.to_s), data, options)
+        @last_response = response = agent.call(method, path.to_s, data, options)
         @raw_responses ? response : response.data
       rescue StandardError => e
         @last_error = e

--- a/lib/looker-sdk/client/dynamic.rb
+++ b/lib/looker-sdk/client/dynamic.rb
@@ -128,8 +128,14 @@ module LookerSDK
           raise ArgumentError.new("wrong number of arguments (#{params_passed} for #{params_required}) in call to '#{method_name}'. See '#{method_link(entry)}'")
         end
 
-        # substitute the actual params into the route template
-        params.each {|param| route.sub!("{#{param[:name]}}", args.shift.to_s) }
+        # substitute the actual params into the route template, encoding if needed
+        params.each do |param|
+          value = args.shift.to_s
+          if value == CGI.unescape(value)
+            value = CGI.escape(value)
+          end
+          route.sub!("{#{param[:name]}}", value)
+        end
 
         a = args.length > 0 ? args[0] : {}
         b = args.length > 1 ? args[1] : {}

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -142,9 +142,21 @@ class LookerDynamicClientTest < MiniTest::Spec
       end
     end
 
-    it "get with parms" do
+    it "get with params" do
       verify(response, :get, '/api/3.0/users/25') do |sdk|
         sdk.user(25)
+      end
+    end
+
+    it "get with params that need encoding" do
+      verify(response, :get, '/api/3.0/users/foo%2Fbar') do |sdk|
+        sdk.user("foo/bar")
+      end
+    end
+
+    it "get with params already encoded" do
+        verify(response, :get, '/api/3.0/users/foo%2Fbar') do |sdk|
+        sdk.user("foo%2Fbar")
       end
     end
 


### PR DESCRIPTION
detect if caller has already supplied encoding and leave alone if so.
othewise encode.

[EMBED-752]

[EMBED-752]: https://looker.atlassian.net/browse/EMBED-752