### PR TITLE
Fix support for older rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 group :test do
   # gem 'json', '~> 1.7', :platforms => [:jruby] look TODO needed?
-  gem 'minitest',         '5.3.5'
+  gem 'minitest',         '5.9.1'
   gem 'mocha',            '1.1.0'
   gem 'rack',             '1.6.4'
   gem 'rack-test',        '0.6.2'

--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,14 @@ test: test-20 test-21 test-23 test-jruby_9150
 test-%:
 	rm -f Gemfile.lock
 	$(with_given_ruby) bundle install --quiet
-	for t in `find test/ -name test_\*.rb` ; do \
-		$(with_given_ruby) rbenv exec bundle exec ruby -I . -I test $$t ; \
-	done
+	$(with_given_ruby) rake
 
 # Installs all ruby versions and their gems
 install: install-20 install-21 install-23 install-jruby_9150
 
 # Install a particular ruby version
 install-ruby-%:
+	rm -f Gemfile.lock
 	rbenv install -s $(given_ruby_version)
 
 # Install gems into a specific ruby version

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,10 @@ test: test-20 test-21 test-23 test-jruby_9150
 # Runs tests against a specific ruby version
 test-%:
 	rm -f Gemfile.lock
-	$(with_given_ruby) bundle lock
-	$(with_given_ruby) bundle exec rake test
+	$(with_given_ruby) bundle install
+	for t in `find test/ -name test_\*.rb` ; do \
+		$(with_given_ruby) rbenv exec bundle exec ruby -I . -I test $$t ; \
+	done
 
 # Installs all ruby versions and their gems
 install: install-20 install-21 install-23 install-jruby_9150

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test: test-20 test-21 test-23 test-jruby_9150
 # Runs tests against a specific ruby version
 test-%:
 	rm -f Gemfile.lock
-	$(with_given_ruby) bundle install
+	$(with_given_ruby) bundle install --quiet
 	for t in `find test/ -name test_\*.rb` ; do \
 		$(with_given_ruby) rbenv exec bundle exec ruby -I . -I test $$t ; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,86 @@
+#############################################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2014 Zee Spencer
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#############################################################################################
+
+# Allows running (and re-running) of tests against several ruby versions,
+# assuming you use rbenv instead of rvm.
+
+# Uses pattern rules (task-$:) and automatic variables ($*).
+# Pattern rules: http://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_10.html#SEC98
+# Automatic variables: http://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_10.html#SEC101
+
+# Rbenv-friendly version identifiers for supported Rubys
+187_version = 1.8.7-p375
+193_version = 1.9.3-p551
+20_version = 2.0.0-p598
+21_version = 2.1.5
+
+# The ruby version for use in a given rule.
+# Requires a matched pattern rule and a supported ruby version.
+#
+# Given a pattern rule defined as "install-ruby-%"
+# When the rule is ran as "install-ruby-193"
+# Then the inner addsuffix call evaluates to "193_version"
+# And given_ruby_version becomes "1.9.3-p551"
+given_ruby_version = $($(addsuffix _version, $*))
+
+# Instruct rbenv on which Ruby version to use when running a command.
+# Requires a pattern rule and a supported ruby version.
+#
+# Given a pattern rule defined as "test-%"
+# When the rule is ran as "test-187"
+# Then with_given_ruby becomes "RBENV_VERSION=1.8.7-p375"
+with_given_ruby = RBENV_VERSION=$(given_ruby_version)
+
+# Watch the fileystem and re-execute a command
+rerun = fswatch -o . | xargs -n1 -I{}
+
+# Runs tests for all supported ruby versions.
+test: test-187 test-193 test-20 test-21
+
+# Runs tests against a specific ruby version
+test-%:
+	$(with_given_ruby) bundle exec ruby test/all.rb
+
+# Watches for changes in the filesystem and re-runs tests for a given ruby.
+retest-%:
+	$(rerun) make test-$*
+
+# Installs all ruby versions and their gems
+install: install-187 install-193 install-20 install-21
+
+
+# Install a particular ruby version
+install-ruby-%:
+	rbenv install -s $(given_ruby_version)
+
+# Install gems into a specific ruby version
+install-gems-%:
+	$(with_given_ruby) gem install bundler
+	$(with_given_ruby) bundle install
+
+
+# Installs a specific ruby version and it's gems
+# At the bottom so it doesn't match install-gems and install-ruby tasks.
+install-%:
+	make install-ruby-$* install-gems-$*

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,6 @@
 # THE SOFTWARE.
 ############################################################################################
 
-require 'bundler'
 require "bundler/gem_tasks"
 
 require "rake/testtask"
@@ -30,32 +29,6 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/test_*.rb"]
   t.verbose = true
-end
-
-namespace :test do
-  desc "Run tests against all supported Rubies"
-  task :all do
-    supported_rubies = %w(ruby-2.0 ruby-2.1 ruby-2.3.1 jruby-1.7.19 jruby-9.1.5.0)
-    failing_rubies = []
-
-    supported_rubies.each do |ruby|
-      cmd = "rvm install #{ruby} && rvm #{ruby} exec gem install bundler && rvm #{ruby} exec bundle install && rvm #{ruby} exec bundle exec rake"
-      system cmd
-      if $? != 0
-        failing_rubies << ruby
-      end
-    end
-
-    failing_rubies.each do |ruby|
-      puts "FAIL: #{ruby}.  Problem with the tests on #{ruby}."
-    end
-
-    if failing_rubies
-      exit 1
-    else
-      exit 0
-    end
-  end
 end
 
 task :default => :test

--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -58,7 +58,9 @@ module LookerSDK
       @original_options = options.dup
 
       load_credentials_from_netrc unless application_credentials?
-      load_swagger
+      if !@lazy_swagger
+        load_swagger
+      end
       self.dynamic = true
     end
 

--- a/lib/looker-sdk/client/dynamic.rb
+++ b/lib/looker-sdk/client/dynamic.rb
@@ -143,11 +143,11 @@ module LookerSDK
 
         method = entry[:method].to_sym
         case method
-        when :get     then get(route, a, &block)
-        when :post    then post(route, a, merge_content_type_if_body(a, b), &block)
-        when :put     then put(route, a, merge_content_type_if_body(a, b), &block)
-        when :patch   then patch(route, a, merge_content_type_if_body(a, b), &block)
-        when :delete  then delete(route, a) ; @raw_responses ? last_response : delete_succeeded?
+        when :get     then get(route, a, true, &block)
+        when :post    then post(route, a, merge_content_type_if_body(a, b), true, &block)
+        when :put     then put(route, a, merge_content_type_if_body(a, b), true, &block)
+        when :patch   then patch(route, a, merge_content_type_if_body(a, b), true, &block)
+        when :delete  then delete(route, a, true) ; @raw_responses ? last_response : delete_succeeded?
         else raise "unsupported method '#{method}' in call to '#{method_name}'. See '#{method_link(entry)}'"
         end
       end

--- a/lib/looker-sdk/configurable.rb
+++ b/lib/looker-sdk/configurable.rb
@@ -66,7 +66,8 @@ module LookerSDK
     attr_accessor :access_token, :auto_paginate, :client_id,
                   :client_secret, :default_media_type, :connection_options,
                   :middleware, :netrc, :netrc_file,
-                  :per_page, :proxy, :user_agent, :faraday, :swagger, :shared_swagger, :raw_responses
+                  :per_page, :proxy, :user_agent, :faraday, :swagger, :shared_swagger, :raw_responses,
+                  :lazy_swagger
     attr_writer :web_endpoint, :api_endpoint
 
     class << self
@@ -92,7 +93,8 @@ module LookerSDK
           :shared_swagger,
           :swagger,
           :raw_responses,
-          :web_endpoint
+          :web_endpoint,
+          :lazy_swagger,
         ]
       end
     end

--- a/lib/looker-sdk/default.rb
+++ b/lib/looker-sdk/default.rb
@@ -125,6 +125,12 @@ module LookerSDK
         false
       end
 
+      # Default behavior for loading swagger during initialization or at first call
+      # @return [Boolean]
+      def lazy_swagger
+        false
+      end
+
       def raw_responses
         false
       end

--- a/lib/looker-sdk/version.rb
+++ b/lib/looker-sdk/version.rb
@@ -26,6 +26,6 @@ module LookerSDK
 
   # Current version
   # @return [String]
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 
 end

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ $ rake install
 ```bash
 $ bundle install
 $ rake test # run the test suite
-$ rake test:all # run the test suite on all supported Rubies
+$ make install test # run the test suite on all supported Rubies
 ```
 
 ### Basic Usage

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,8 @@ $ rake install
 
 ### Development
 
+Customize test/fixtures/.netrc for tests to pass
+Comment out coverage configuration in test/helper.rb for debugging
 ```bash
 $ bundle install
 $ rake test # run the test suite

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -57,6 +57,7 @@ fix_netrc_permissions(File.join(fixture_path, '.netrc'))
 def setup_sdk
   LookerSDK.reset!
   LookerSDK.configure do |c|
+    c.lazy_swagger = true
     c.connection_options = {:ssl => {:verify => false}}
     c.netrc = true
     c.netrc_file =  File.join(fixture_path, '.netrc')
@@ -64,7 +65,6 @@ def setup_sdk
 end
 
 def teardown_sdk
+  setup_sdk  # put back initial config
   LookerSDK.logout
 end
-
-

--- a/test/looker/test_client.rb
+++ b/test/looker/test_client.rb
@@ -30,10 +30,6 @@ describe LookerSDK::Client do
    setup_sdk
   end
 
-  after(:each) do
-   teardown_sdk
-  end
-
   describe "lazy load swagger" do
 
     it "lazy loads swagger" do
@@ -268,6 +264,40 @@ describe LookerSDK::Client do
       end
     end
 
+    [
+        [:get, '/api/3.0/users/foo%2Fbar', false],
+        [:get, '/api/3.0/users/foo%252Fbar', true],
+        [:post, '/api/3.0/users/foo%2Fbar', false],
+        [:post, '/api/3.0/users/foo%252Fbar', true],
+        [:put, '/api/3.0/users/foo%2Fbar', false],
+        [:put, '/api/3.0/users/foo%252Fbar', true],
+        [:patch, '/api/3.0/users/foo%2Fbar', false],
+        [:patch, '/api/3.0/users/foo%252Fbar', true],
+        [:delete, '/api/3.0/users/foo%2Fbar', false],
+        [:delete, '/api/3.0/users/foo%252Fbar', true],
+        [:head, '/api/3.0/users/foo%2Fbar', false],
+        [:head, '/api/3.0/users/foo%252Fbar', true],
+    ].each do |method, path, encoded|
+      it "handles request path encoding" do
+        expected_path = '/api/3.0/users/foo%252Fbar'
+
+        resp = OpenStruct.new(:data => "hi", :status => 204)
+        mock = MiniTest::Mock.new.expect(:call, resp, [method, expected_path, nil, {}])
+        Sawyer::Agent.stubs(:new).returns(mock, mock)
+
+        sdk = LookerSDK::Client.new
+        if [:get, :delete, :head].include? method
+          args = [method, path, nil, encoded]
+        else
+          args = [method, path, nil, nil, encoded]
+        end
+        sdk.without_authentication do
+          value = sdk.public_send *args
+          assert_equal "hi", value
+        end
+        mock.verify
+      end
+    end
   end
 
   describe 'Sawyer date/time parsing patch' do

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -103,7 +103,7 @@ class LookerDynamicClientTest < MiniTest::Spec
       resp = [200, {'Content-Type' => 'application/json'}, [default_swagger.to_json]]
       mock = MiniTest::Mock.new.expect(:call, resp, [Hash])
       sdk = sdk_client(nil, mock)
-      assert_equal sdk.swagger, default_swagger
+      assert_equal default_swagger, sdk.swagger
     end
 
     it "loads swagger with authentication" do
@@ -111,7 +111,7 @@ class LookerDynamicClientTest < MiniTest::Spec
       mock = MiniTest::Mock.new.expect(:call, nil) {raise "login first!"}
       mock.expect(:call, resp, [Hash])
       sdk = sdk_client(nil, mock)
-      assert_equal sdk.swagger, default_swagger
+      assert_equal default_swagger, sdk.swagger
     end
 
     it "invalid method name" do

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -36,6 +36,7 @@ class LookerDynamicClientTest < MiniTest::Spec
       conn.adapter :rack, engine
     end
 
+    LookerSDK.reset!
     LookerSDK::Client.new do |config|
       config.swagger = swagger
       config.access_token = access_token


### PR DESCRIPTION
The introduction of the safe navigation operator in 91d1c98 broke the sdk for versions 2.0 and 2.1 This change converts to ternary operators instead and also fixes support for testing against supported ruby version. 