### PR TITLE
index operations hash by symbol instead of string

### DIFF
--- a/lib/looker-sdk/client/dynamic.rb
+++ b/lib/looker-sdk/client/dynamic.rb
@@ -114,7 +114,7 @@ module LookerSDK
       private
 
       def find_entry(method_name)
-        operations && operations[method_name] if dynamic
+        operations && operations[method_name.to_sym] if dynamic
       end
 
       def invoke_remote(entry, method_name, *args, &block)

--- a/lib/looker-sdk/client/dynamic.rb
+++ b/lib/looker-sdk/client/dynamic.rb
@@ -81,7 +81,7 @@ module LookerSDK
           @swagger[:paths].map do |path_name, path_info|
             path_info.map do |method, route_info|
               route = @swagger[:basePath].to_s + path_name.to_s
-              [route_info[:operationId], {:route => route, :method => method, :info => route_info}]
+              [route_info[:operationId].to_sym, {:route => route, :method => method, :info => route_info}]
             end
           end.reduce(:+)
         ].freeze
@@ -114,7 +114,7 @@ module LookerSDK
       private
 
       def find_entry(method_name)
-        operations && operations[method_name.to_s] if dynamic
+        operations && operations[method_name] if dynamic
       end
 
       def invoke_remote(entry, method_name, *args, &block)

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -116,8 +116,7 @@ class LookerDynamicClientTest < MiniTest::Spec
     end
 
     it "invalid method name" do
-      mock = MiniTest::Mock.new.expect(:call, response){|env| confirm_env(env, :get, path, body, query, content_type)}
-      sdk = sdk_client(default_swagger, mock)
+      sdk = sdk_client(default_swagger, nil)
       assert_raises NoMethodError do
         sdk.this_method_name_doesnt_exist()
       end

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -133,7 +133,7 @@ class LookerDynamicClientTest < MiniTest::Spec
         end
       end
 
-      it "find_entry by symbol operationId" do
+      it "invoke by symbol operationId" do
         verify(response, :get, '/api/3.0/user') do |sdk|
           sdk.invoke(:me)
         end

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -116,7 +116,7 @@ class LookerDynamicClientTest < MiniTest::Spec
     end
 
     it "invalid method name" do
-      mock = MiniTest::Mock.new.expect(:call, response){|env| confirm_env(env, method, path, body, query, content_type)}
+      mock = MiniTest::Mock.new.expect(:call, response){|env| confirm_env(env, :get, path, body, query, content_type)}
       sdk = sdk_client(default_swagger, mock)
       assert_raises NoMethodError do
         sdk.this_method_name_doesnt_exist()
@@ -124,6 +124,20 @@ class LookerDynamicClientTest < MiniTest::Spec
 
       assert_raises NameError do
         sdk.invoke(:this_method_name_doesnt_exist)
+      end
+    end
+
+    describe "operation maps" do
+      it "invoke by string operationId" do
+        verify(response, :get, '/api/3.0/user') do |sdk|
+          sdk.invoke('me')
+        end
+      end
+
+      it "find_entry by symbol operationId" do
+        verify(response, :get, '/api/3.0/user') do |sdk|
+          sdk.invoke(:me)
+        end
       end
     end
 


### PR DESCRIPTION
string compare in ruby is a lot more expensive than symbol compare.
plus, API calls like `sdk.something` will already have made `something` into a symbol before execution reaches `method_missing`, so why not just use it?
