### PR TITLE
Increase faraday version upper bound

### DIFF
--- a/lib/looker-sdk.rb
+++ b/lib/looker-sdk.rb
@@ -43,7 +43,6 @@ require 'faraday/rack_builder'
 require 'faraday/request'
 require 'faraday/request/authorization'
 require 'faraday/response'
-require 'faraday/upload_io'
 require 'faraday/utils'
 
 #require 'rack'

--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.add_dependency 'jruby-openssl' if s.platform == :jruby
   s.add_dependency 'sawyer', '~> 0.8'
-  s.add_dependency 'faraday', ['>= 0.9.0', '< 1.0']
+  s.add_dependency 'faraday', ['>= 0.9.0', '< 2.0']
 end


### PR DESCRIPTION
Having a dependency on faraday < 1.0 prevents users from updating their dependecies that depend on newer versions of faraday. Versions of faraday < 1.0 also have a lot of warnings when used with Ruby 2.7 and will not work at all with Ruby 3.0