### PR TITLE
feat: upgrade faraday dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,8 @@
 # Automatic variables: http://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_10.html#SEC101
 
 # Rbenv-friendly version identifiers for supported Rubys
-20_version = 2.0.0-p648
-21_version = 2.1.10
-23_version = 2.3.1
-jruby_9150_version = jruby-9.1.5.0
+25_version = 2.5.7
+jruby_92160_version = jruby-9.2.16.0
 
 # The ruby version for use in a given rule.
 # Requires a matched pattern rule and a supported ruby version.
@@ -54,7 +52,7 @@ given_ruby_version = $($(addsuffix _version, $*))
 with_given_ruby = RBENV_VERSION=$(given_ruby_version)
 
 # Runs tests for all supported ruby versions.
-test: test-20 test-21 test-23 test-jruby_9150
+test: test-25 test-jruby_92160
 
 # Runs tests against a specific ruby version
 test-%:
@@ -63,7 +61,7 @@ test-%:
 	$(with_given_ruby) rake
 
 # Installs all ruby versions and their gems
-install: install-20 install-21 install-23 install-jruby_9150
+install: install-25 install-jruby_92160
 
 # Install a particular ruby version
 install-ruby-%:
@@ -76,17 +74,6 @@ install-gems-%:
 	$(with_given_ruby) gem update --system
 	$(with_given_ruby) gem install bundler
 	$(with_given_ruby) bundle install
-
-# special case 20 and 21 need older bundler
-install-gems-20:
-	rm -f Gemfile.lock
-	RBENV_VERSION=$(20_version) gem install bundler -v '~>1'
-	RBENV_VERSION=$(20_version) bundle install
-
-install-gems-21:
-	rm -f Gemfile.lock
-	RBENV_VERSION=$(21_version) gem install bundler -v '~>1'
-	RBENV_VERSION=$(21_version) bundle install
 
 # Installs a specific ruby version and it's gems
 # At the bottom so it doesn't match install-gems and install-ruby tasks.

--- a/lib/looker-sdk.rb
+++ b/lib/looker-sdk.rb
@@ -43,7 +43,6 @@ require 'faraday/rack_builder'
 require 'faraday/request'
 require 'faraday/request/authorization'
 require 'faraday/response'
-require 'faraday/upload_io'
 require 'faraday/utils'
 
 #require 'rack'

--- a/lib/looker-sdk/response/raise_error.rb
+++ b/lib/looker-sdk/response/raise_error.rb
@@ -30,9 +30,7 @@ module LookerSDK
   module Response
 
     # HTTP status codes returned by the API
-    class RaiseError < Faraday::Response::Middleware
-
-      private
+    class RaiseError < Faraday::Middleware
 
       def on_complete(response)
         if error = LookerSDK::Error.from_response(response)

--- a/lib/looker-sdk/version.rb
+++ b/lib/looker-sdk/version.rb
@@ -26,6 +26,6 @@ module LookerSDK
 
   # Current version
   # @return [String]
-  VERSION = "0.0.8"
+  VERSION = "0.1.0"
 
 end

--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
       'the Looker data analytics engine to fetch data or render visualizations defined in your Looker data models. '+
       'For more information, see https://looker.com.'
   s.license     = 'MIT'
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.5'
   s.requirements = 'Looker version 4.0 or later'  # informational
 
   s.files         = `git ls-files`.split("\n")
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.add_dependency 'jruby-openssl' if s.platform == :jruby
   s.add_dependency 'sawyer', '~> 0.8'
-  s.add_dependency 'faraday', ['>= 0.9.0', '< 1.0']
+  s.add_dependency 'faraday', ['>= 1.0', '< 2.0']
 end


### PR DESCRIPTION
- new interface for middleware
-- https://lostisland.github.io/faraday/middleware/custom
- as of version 0.1.0, ruby 2.5 is the oldest version we support

fixes #99 